### PR TITLE
feat: implement configurable timeouts (Issue #11)

### DIFF
--- a/aiclient/models/chat.py
+++ b/aiclient/models/chat.py
@@ -43,6 +43,7 @@ class ChatModel:
         top_p: float = None,
         top_k: int = None,
         stop: Union[str, List[str]] = None,
+        timeout: float = None,
     ) -> Union[ModelResponse, T]:
         """
         Generate a response synchronously.
@@ -100,7 +101,7 @@ class ChatModel:
         response_data = None
         for attempt in range(self.max_retries + 1):
             try:
-                response_data = self.transport.send(endpoint, data)
+                response_data = self.transport.send(endpoint, data, timeout=timeout)
                 break
             except Exception as e:
                 # Notify middleware of error
@@ -152,6 +153,7 @@ class ChatModel:
         top_p: float = None,
         top_k: int = None,
         stop: Union[str, List[str]] = None,
+        timeout: float = None,
     ) -> Union[ModelResponse, T]:
         """
         Generate a response asynchronously.
@@ -205,7 +207,7 @@ class ChatModel:
         response_data = None
         for attempt in range(self.max_retries + 1):
             try:
-                response_data = await self.transport.send_async(endpoint, data)
+                response_data = await self.transport.send_async(endpoint, data, timeout=timeout)
                 break
             except Exception as e:
                 # Notify middleware of error
@@ -254,6 +256,7 @@ class ChatModel:
         top_p: float = None,
         top_k: int = None,
         stop: Union[str, List[str]] = None,
+        timeout: float = None,
     ) -> Iterator[str]:
         """Stream a response asynchronously."""
         # 1. Prepare Messages
@@ -276,7 +279,7 @@ class ChatModel:
             stop=stop,
         )
         try:
-            async for chunk_data in self.transport.stream_async(endpoint, data):
+            async for chunk_data in self.transport.stream_async(endpoint, data, timeout=timeout):
                 chunk = self.provider.parse_stream_chunk(chunk_data)
                 if chunk:
                     yield chunk.text
@@ -292,6 +295,7 @@ class ChatModel:
         top_p: float = None,
         top_k: int = None,
         stop: Union[str, List[str]] = None,
+        timeout: float = None,
     ) -> Iterator[str]:
         """Stream a response synchronously."""
         # 1. Prepare Messages
@@ -314,7 +318,7 @@ class ChatModel:
             stop=stop,
         )
         try:
-            for chunk_data in self.transport.stream(endpoint, data):
+            for chunk_data in self.transport.stream(endpoint, data, timeout=timeout):
                 chunk = self.provider.parse_stream_chunk(chunk_data)
                 if chunk:
                     yield chunk.text

--- a/aiclient/transport/base.py
+++ b/aiclient/transport/base.py
@@ -6,20 +6,20 @@ class Transport(Protocol):
     Abstract interface for network transport.
     """
 
-    def send(self, endpoint: str, data: Dict[str, Any]) -> Dict[str, Any]:
+    def send(self, endpoint: str, data: Dict[str, Any], timeout: float = None) -> Dict[str, Any]:
         """Send a synchronous request."""
         ...
 
-    async def send_async(self, endpoint: str, data: Dict[str, Any]) -> Dict[str, Any]:
+    async def send_async(self, endpoint: str, data: Dict[str, Any], timeout: float = None) -> Dict[str, Any]:
         """Async version of send."""
         ...
 
-    def stream(self, endpoint: str, data: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
+    def stream(self, endpoint: str, data: Dict[str, Any], timeout: float = None) -> Iterator[Dict[str, Any]]:
         """Stream a synchronous request."""
         ...
 
     async def stream_async(
-        self, endpoint: str, data: Dict[str, Any]
+        self, endpoint: str, data: Dict[str, Any], timeout: float = None
     ) -> AsyncIterator[Dict[str, Any]]:
         """Stream an asynchronous request."""
         ...

--- a/aiclient/transport/http.py
+++ b/aiclient/transport/http.py
@@ -84,28 +84,37 @@ class HTTPTransport(Transport):
             logger.error(f"Unexpected Error: {e}")
             raise AIClientError(f"Unexpected error: {e}") from e
 
-    def send(self, endpoint: str, data: Dict[str, Any]) -> Dict[str, Any]:
-        logger.debug(f"SEND {endpoint} payload={data}")
+    def send(self, endpoint: str, data: Dict[str, Any], timeout: float = None) -> Dict[str, Any]:
+        logger.debug(f"SEND {endpoint} payload={data} timeout={timeout}")
         try:
-            response = self.client.post(endpoint, json=data)
+            kwargs = {}
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            response = self.client.post(endpoint, json=data, **kwargs)
             response.raise_for_status()
             return response.json()
         except Exception as e:
             self._handle_error(e, "Sync send failed")
 
-    async def send_async(self, endpoint: str, data: Dict[str, Any]) -> Dict[str, Any]:
-        logger.debug(f"ASYNC SEND {endpoint} payload={data}")
+    async def send_async(self, endpoint: str, data: Dict[str, Any], timeout: float = None) -> Dict[str, Any]:
+        logger.debug(f"ASYNC SEND {endpoint} payload={data} timeout={timeout}")
         try:
-            response = await self.aclient.post(endpoint, json=data)
+            kwargs = {}
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            response = await self.aclient.post(endpoint, json=data, **kwargs)
             response.raise_for_status()
             return response.json()
         except Exception as e:
             self._handle_error(e, "Async send failed")
 
-    def stream(self, endpoint: str, data: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
-        logger.debug(f"STREAM {endpoint} payload={data}")
+    def stream(self, endpoint: str, data: Dict[str, Any], timeout: float = None) -> Iterator[Dict[str, Any]]:
+        logger.debug(f"STREAM {endpoint} payload={data} timeout={timeout}")
         try:
-            with self.client.stream("POST", endpoint, json=data) as response:
+            kwargs = {}
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            with self.client.stream("POST", endpoint, json=data, **kwargs) as response:
                 response.raise_for_status()
                 for line in response.iter_lines():
                     if line:
@@ -114,11 +123,14 @@ class HTTPTransport(Transport):
             self._handle_error(e, "Stream failed")
 
     async def stream_async(
-        self, endpoint: str, data: Dict[str, Any]
+        self, endpoint: str, data: Dict[str, Any], timeout: float = None
     ) -> AsyncIterator[Dict[str, Any]]:
-        logger.debug(f"ASYNC STREAM {endpoint} payload={data}")
+        logger.debug(f"ASYNC STREAM {endpoint} payload={data} timeout={timeout}")
         try:
-            async with self.aclient.stream("POST", endpoint, json=data) as response:
+            kwargs = {}
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            async with self.aclient.stream("POST", endpoint, json=data, **kwargs) as response:
                 response.raise_for_status()
                 async for line in response.aiter_lines():
                     if line:

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,0 +1,79 @@
+
+import pytest
+import httpx
+from unittest.mock import MagicMock, patch
+from aiclient.client import Client
+from aiclient.transport.http import HTTPTransport
+from aiclient.providers.openai import OpenAIProvider
+
+def test_default_client_timeout():
+    """Test that client initialization sets the default timeout on transport."""
+    client = Client(openai_api_key="mock", timeout=45.0)
+    provider, _ = client._get_provider("gpt-4o")
+    
+    # Manually create transport to verify init params
+    transport = client.transport_factory(
+        base_url=provider.base_url, 
+        headers=provider.headers, 
+        timeout=client.timeout
+    )
+    
+    assert transport.timeout == 45.0
+    assert transport.client.timeout.read == 45.0
+    assert transport.aclient.timeout.read == 45.0
+
+def test_override_timeout_generate():
+    """Test that passing timeout to generate() overrides the default."""
+    client = Client(openai_api_key="mock", timeout=10.0)
+    
+    # Mock the internal transport.send method to check arguments
+    with patch("aiclient.transport.http.HTTPTransport.send") as mock_send:
+        # We need to mock response or send will crash trying to return
+        mock_send.return_value = {
+            "choices": [{"message": {"content": "Hello"}}],
+            "usage": {}
+        }
+        
+        client.chat("gpt-4o").generate("Hello", timeout=5.0)
+        
+        # Verify call args
+        args, kwargs = mock_send.call_args
+        assert kwargs["timeout"] == 5.0
+
+@pytest.mark.asyncio
+async def test_override_timeout_generate_async():
+    """Test specific timeout override on async generation."""
+    client = Client(openai_api_key="mock", timeout=10.0)
+    
+    with patch("aiclient.transport.http.HTTPTransport.send_async") as mock_send:
+        mock_send.return_value = {
+            "choices": [{"message": {"content": "Hello"}}],
+            "usage": {}
+        }
+        
+        await client.chat("gpt-4o").generate_async("Hello", timeout=2.5)
+        
+        args, kwargs = mock_send.call_args
+        assert kwargs["timeout"] == 2.5
+
+def test_no_timeout_override_uses_default():
+    """Test that not passing timeout uses the client default (implicitly via httpx client)."""
+    client = Client(openai_api_key="mock", timeout=20.0)
+    
+    with patch("aiclient.transport.http.HTTPTransport.send") as mock_send:
+        mock_send.return_value = {
+            "choices": [{"message": {"content": "Hello"}}],
+            "usage": {}
+        }
+        
+        client.chat("gpt-4o").generate("Hello")
+        
+        # kwargs should NOT contain timeout if we didn't pass it, 
+        # allowing the underlying httpx client (configured with default) to handle it.
+        # OR our implementation passes None/nothing.
+        # Our implementation passes `timeout=None` if not provided? 
+        # No, update: if timeout is None, we don't put it in kwargs.
+        
+        args, kwargs = mock_send.call_args
+        assert "timeout" not in kwargs or kwargs["timeout"] is None
+


### PR DESCRIPTION
## Changes:

Updated Transport protocol and HTTPTransport to accept timeout.
Updated ChatModel.generate() and related methods to accept timeout and pass it down.
Added tests/test_timeouts.py and verified that timeouts can be overridden per-request.


@zlowred Have a look 